### PR TITLE
Fix windows style paths

### DIFF
--- a/lib/connections/Connection.js
+++ b/lib/connections/Connection.js
@@ -43,4 +43,11 @@ Connection.prototype.uploadFiles = function (aFiles) {
 Connection.prototype.downloadFiles = function (aFiles) {
 };
 
+/**
+ * @param {String} sPath
+ */
+Connection.prototype.normalizePath = function (sPath) {
+  return sPath.replace(/\\/g, '/');
+};
+
 module.exports = Connection;

--- a/lib/connections/FtpConnection.js
+++ b/lib/connections/FtpConnection.js
@@ -63,8 +63,8 @@ FtpConnection.prototype.uploadFiles = function (aFiles) {
   self.nbFiles = aFiles.length;
 
   aFiles.forEach(function(file) {
-    var destinationFile = path.join(self.config.getRemotePath(), file.getPath());
-    var destinationDirectory = path.dirname(destinationFile);
+    var destinationFile = self.normalizePath(path.join(self.config.getRemotePath(), file.getPath()));
+    var destinationDirectory = self.normalizePath(path.dirname(destinationFile));
 
     self.emit('ftp_mkdir', destinationDirectory);
     self.connection.mkdir(destinationDirectory, true, function (err) {
@@ -94,7 +94,7 @@ FtpConnection.prototype.downloadFiles = function (aFiles) {
   self.nbFiles = aFiles.length;
 
   aFiles.forEach(function(file) {
-    var sourceFile = path.join(self.config.getRemotePath(), file.getPath());
+    var sourceFile = self.normalizePath(path.join(self.config.getRemotePath(), file.getPath()));
     var destinationFile = path.join(atom.project.path, file.getPath());
     self.emit('ftp_download_file', file.getPath());
     self.connection.get(sourceFile, function(err, stream) {

--- a/lib/connections/SftpConnection.js
+++ b/lib/connections/SftpConnection.js
@@ -69,8 +69,8 @@ SftpConnection.prototype.uploadFiles = function (aFiles) {
     });
 
     aFiles.forEach(function(file) {
-      var destinationFile = path.join(self.config.getRemotePath(), file.getPath());
-      var destinationDirectory = path.dirname(destinationFile);
+      var destinationFile = self.normalizePath(path.join(self.config.getRemotePath(), file.getPath()));
+      var destinationDirectory = self.normalizePath(path.dirname(destinationFile));
 
       self.emit('sftp_mkdir', destinationDirectory);
       self.connection.exec('mkdir -p ' + destinationDirectory, function (err) {
@@ -109,7 +109,7 @@ SftpConnection.prototype.downloadFiles = function (aFiles) {
     });
 
     aFiles.forEach(function(file) {
-      var sourceFile = path.join(self.config.getRemotePath(), file.getPath());
+      var sourceFile = self.normalizePath(path.join(self.config.getRemotePath(), file.getPath()));
       var destinationFile = path.join(atom.project.path, file.getPath());
       self.emit('sftp_download_file', file.getPath());
       sftp.fastGet(sourceFile, destinationFile, function(err) {


### PR DESCRIPTION
- new method on `Connection`: `normalizePath`
- `Ftp`- and `SftpConnection` use `normalizePath` only when communicating with
server

Fixes: #22, #18, #17, #8

Justification to put fix in `Connection` instead of `FileManager`:
- `FileManager` could normalize the paths of the `Files` it emits, however the paths must still be `join`ed onto the Atom project directory, which will use `path.sep` anyway.
- `Connection#normalizePath` only needs to be called on paths sent to the server; local paths do not need to be normalized.