### PR TITLE
Improve spelling / wording of prompts

### DIFF
--- a/lib/DeploymentManager.js
+++ b/lib/DeploymentManager.js
@@ -86,8 +86,8 @@ DeploymentManager.prototype.generateConfigFile = function() {
   }
 
   atom.confirm({
-    message: "Which type of configuration you want to generate ?",
-    detailedMessage: "Be careful, this will overwrite the existent configuration file !",
+    message: "Which type of configuration would you like to generate?",
+    detailedMessage: "Be careful—this will overwrite the existing configuration file!",
     buttons: {
       "SFTP": function () {
         writeConfig(configFactory.getSftpConfig());
@@ -225,7 +225,7 @@ DeploymentManager.prototype.uploadCurrentFile = function() {
  */
 DeploymentManager.prototype.downloadCurrentFile = function() {
   atom.confirm({
-    message: "You will download the current file, be careful, it will be overwritted.",
+    message: "Warning: you are downloading a single file. If a file exists with this same name, it will be overwritten. Proceed?",
     buttons: {
       "Overwrite": function () {
         var connectionReady = function (connection) {
@@ -299,7 +299,7 @@ DeploymentManager.prototype.uploadSelection = function() {
  */
 DeploymentManager.prototype.downloadSelection = function() {
   atom.confirm({
-    message: "You will download all your selection, be careful, it will be overwritted.",
+    message: "Warning: you are downloading multiple files. Any files with the same names as your selection will be overwritten. Proceed?",
     buttons: {
       "Overwrite": function () {
         var connectionReady = function (connection) {


### PR DESCRIPTION
I was using your plugin and noticed some spelling errors in the dialog boxes (`overwritted` changed to `overwritten`, etc.). Here is one suggestion for some improved copy.