### PR TITLE
Add new Remote System Error Exception and use for stderr exceptions

### DIFF
--- a/lib/DeploymentManager.js
+++ b/lib/DeploymentManager.js
@@ -19,6 +19,7 @@ var ConnectionErrorException = require('./exceptions/ConnectionErrorException');
 var UploadErrorException = require('./exceptions/UploadErrorException');
 var DownloadErrorException = require('./exceptions/DownloadErrorException');
 var RemoteDirectoryCreationErrorException = require('./exceptions/RemoteDirectoryCreationErrorException');
+var RemoteSystemErrorException = require('./exceptions/RemoteSystemErrorException');
 var DirectoryCreationErrorException = require('./exceptions/DirectoryCreationErrorException');
 var TransfertErrorException = require('./exceptions/TransfertErrorException');
 var RemoteDirectoryNotReadableException = require('./exceptions/RemoteDirectoryNotReadableException');
@@ -92,6 +93,9 @@ DeploymentManager.prototype.upload = function(files) {
         })
         .catch(RemoteDirectoryCreationErrorException, function(e) {
             self.notifyObservers('remote_directory_creation_error', e);
+        })
+        .catch(RemoteSystemErrorException, function(e) {
+            self.notifyObservers('remote_system_error', e);
         })
         .catch(TransfertErrorException, function(e) {
             self.notifyObservers('transfert_file_error', e);

--- a/lib/connections/SftpConnection.js
+++ b/lib/connections/SftpConnection.js
@@ -14,6 +14,7 @@ var File = require('./../filesystem/File');
 var UploadErrorException = require('./../exceptions/UploadErrorException');
 var DownloadErrorException = require('./../exceptions/DownloadErrorException');
 var RemoteDirectoryCreationErrorException = require('./../exceptions/RemoteDirectoryCreationErrorException');
+var RemoteSystemErrorException = require('./../exceptions/RemoteSystemErrorException');
 var TransfertErrorException = require('./../exceptions/TransfertErrorException');
 var RemoteDirectoryNotReadableException = require('./../exceptions/RemoteDirectoryNotReadableException');
 
@@ -67,7 +68,7 @@ SftpConnection.prototype.createRemoteDirectory = function(directoryPath) {
                     deferred.resolve(directoryPath);
                 });
                 stream.stderr.on('data', function(data) {
-                    deferred.reject(new RemoteDirectoryCreationErrorException(directoryPath));
+                    deferred.reject(new RemoteSystemErrorException(data.toString()));
                 });
             }
         );

--- a/lib/exceptions/RemoteSystemErrorException.js
+++ b/lib/exceptions/RemoteSystemErrorException.js
@@ -1,0 +1,18 @@
+var util = require('util');
+
+var Exception = require('./Exception');
+
+//////////////////
+// Ctor
+//////////////////
+
+function RemoteSystemErrorException(msg) {
+    Exception.apply(
+        this,
+        ['Remote System Error: "' + msg + '"']
+    );
+}
+
+util.inherits(RemoteSystemErrorException, Exception);
+
+module.exports = RemoteSystemErrorException;

--- a/lib/observers/MessageObserver.js
+++ b/lib/observers/MessageObserver.js
@@ -105,6 +105,9 @@ MessageObserver.prototype.notify = function(value, data) {
         case 'directory_creation_error':
             createErrorMessage(data.message);
             break;
+        case 'remote_system_error':
+            createErrorMessage(data.message);
+            break;
         case 'upload_file_error':
             createErrorMessage(data.message);
             break;


### PR DESCRIPTION
- Created RemoteSystemErrorException
- Use new exception to catch stderr output of create directory command. These exceptions can be irrelevant to command used.
- Catch error and throw nice message in observer

Fixes this issue https://github.com/amoussard/sftp-deployment/issues/94

Basic issue is that you might get something stderr which is irrelevant to command run and thus want to display to user to allow debugging. I suspect there might be other places where this type of generic error would be useful but haven't looked.

Let me know if you want me to change anything or thought of a better way to implement this?