### PR TITLE
fixed issue #120 & #121 , update version of expand-home-dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "util": "*",
     "node-dir": "*",
     "bluebird": "^2.9.16",
-    "expand-home-dir": "^0.0.2",
+    "expand-home-dir": "^0.0.3",
     "atom-space-pen-views": "^2.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## About
I fixed issue #120 & #121.

I think this problem caused by version-up of expand-home-dir.

So, I changed package.json for this error message
```
npm ERR! notarget No compatible version found: expand-home-dir@'>=0.0.2 <0.0.3'
```

expand-home-dir has been upgraded in this commit
https://github.com/n-johnson/expand-home-dir/commit/14f54a4ae94d86bafdd36d91551eb9809d0add63

Please check this.