### PR TITLE
Use sftp's mkdir instead of exec

### DIFF
--- a/lib/connections/SftpConnection.js
+++ b/lib/connections/SftpConnection.js
@@ -14,7 +14,6 @@ var File = require('./../filesystem/File');
 var UploadErrorException = require('./../exceptions/UploadErrorException');
 var DownloadErrorException = require('./../exceptions/DownloadErrorException');
 var RemoteDirectoryCreationErrorException = require('./../exceptions/RemoteDirectoryCreationErrorException');
-var RemoteSystemErrorException = require('./../exceptions/RemoteSystemErrorException');
 var TransfertErrorException = require('./../exceptions/TransfertErrorException');
 var RemoteDirectoryNotReadableException = require('./../exceptions/RemoteDirectoryNotReadableException');
 
@@ -53,29 +52,38 @@ SftpConnection.prototype.getConnectionInformations = function() {
     return informations;
 }
 
-SftpConnection.prototype.createRemoteDirectory = function(directoryPath) {
+SftpConnection.prototype.createRemoteDirectory = function(sftp, directoryPath) {
     var deferred = Promise.pending();
 
-    try {
-        var success = this.connection.exec(
-            'mkdir -p ' + directoryPath,
-            function (err, stream) {
-                if (err) {
+    var segments = directoryPath.split(/\//g);
+    var remote_path = '';
+
+    function mkdirp() {
+        if (!segments.length) {
+            deferred.resolve(sftp);
+        } else {
+
+            var segment = segments.shift();
+            segment += '/';
+
+            remote_path = path.join(remote_path, segment);
+
+            sftp.mkdir(remote_path, function(err, stream) {
+                if (err && err.code != 4) {
                     deferred.reject(new RemoteDirectoryCreationErrorException(directoryPath));
+                } else {
+                    mkdirp();
                 }
-
-                stream.on('close', function() {
-                    deferred.resolve(directoryPath);
-                });
-                stream.stderr.on('data', function(data) {
-                    deferred.reject(new RemoteSystemErrorException(data.toString()));
-                });
-            }
-        );
-    } catch(e) {
-        deferred.reject(e);
+            });
+        }
     }
-
+    sftp.lstat(directoryPath, function(err, stream) {
+        if (err) {
+            mkdirp();
+        } else {
+            deferred.resolve(sftp);
+        }
+    })
     return deferred.promise;
 }
 
@@ -146,9 +154,9 @@ SftpConnection.prototype.uploadFile = function(file) {
     ).replace(/\\/g, '/');
 
     try {
-        this.createRemoteDirectory(path.dirname(destinationFile))
-            .then(function(directory) {
-                return self.openSftp();
+        this.openSftp()
+            .then(function(sftp) {
+              return self.createRemoteDirectory(sftp, path.dirname(destinationFile));
             })
             .then(function(sftp) {
                 return self.fastPut(sftp, file.getPath(), destinationFile);


### PR DESCRIPTION
SftpConnection.prototype.createRemoteDirectory now purely uses the SFTP
subsystem instead of relying on exec and mkdir -p. This ensures that
sftp-deployment works in chroot’ed environments.
